### PR TITLE
Add CSV export endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,12 +68,11 @@ def eliminar_tarea(tarea_id):
 @app.route("/tareas/export", methods=["GET"])
 def exportar_tareas_csv():
     """Devuelve todas las tareas en formato CSV."""
-    buffer = StringIO()
-    writer = csv.DictWriter(buffer, fieldnames=["id", "titulo", "descripcion", "hecho"])
-    writer.writeheader()
-    writer.writerows(tareas)
-    csv_data = buffer.getvalue()
-    buffer.close()
+    with StringIO() as buffer:
+        writer = csv.DictWriter(buffer, fieldnames=["id", "titulo", "descripcion", "hecho"])
+        writer.writeheader()
+        writer.writerows(tareas)
+        csv_data = buffer.getvalue()
     response = Response(csv_data, mimetype="text/csv")
     response.headers["Content-Disposition"] = "attachment; filename=tareas.csv"
     return response

--- a/app.py
+++ b/app.py
@@ -1,4 +1,6 @@
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, Response
+import csv
+from io import StringIO
 
 app = Flask(__name__)
 
@@ -61,6 +63,20 @@ def eliminar_tarea(tarea_id):
         return jsonify({"error": "Tarea no encontrada"}), 404
     tareas.remove(tarea[0])
     return jsonify({"resultado": "Tarea eliminada"})
+
+# Nuevo endpoint para exportar tareas en formato CSV
+@app.route("/tareas/export", methods=["GET"])
+def exportar_tareas_csv():
+    """Devuelve todas las tareas en formato CSV."""
+    buffer = StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=["id", "titulo", "descripcion", "hecho"])
+    writer.writeheader()
+    writer.writerows(tareas)
+    csv_data = buffer.getvalue()
+    buffer.close()
+    response = Response(csv_data, mimetype="text/csv")
+    response.headers["Content-Disposition"] = "attachment; filename=tareas.csv"
+    return response
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/readme.md
+++ b/readme.md
@@ -125,3 +125,13 @@ This API allows you to manage a list of tasks. You can create, retrieve, update,
     "error": "Tarea no encontrada"
   }
   ```
+
+### Export Tasks as CSV
+- **Endpoint:** `/tareas/export`
+- **Method:** `GET`
+- **Response:** Returns a CSV file (`text/csv`) containing all tasks. Example content:
+  ```csv
+  id,titulo,descripcion,hecho
+  1,Comprar leche,Ir a la tienda y comprar leche,False
+  2,Estudiar Python,Completar el tutorial de Python,False
+  ```


### PR DESCRIPTION
## Summary
- add CSV export route to serve tasks as `tareas.csv`
- document `/tareas/export` endpoint in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843514b62d0832db3fd07b909c00545